### PR TITLE
Update company URLs to placeholders for feature employer logos

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
             <nav className="flex items-center space-x-6">
               <Link href="/">Home</Link>
               <Link href="/about">About</Link>
-              <Link href="#">Skill</Link>
+              <Link href="/skills">Skill</Link>
               <Link href="#">Find a Job</Link>
               <Link href="#">Employer</Link>
               <Link href="/auth/login">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,47 +8,47 @@ export default function HomePage() {
     {
       name: "Google",
       logo: "/Google-Logo.png",
-      url: "https://companyA.com",
+      url: "#",
     },
     {
       name: "Facebook",
       logo: "/Facebook-Logo.png",
-      url: "https://companyB.com",
+      url: "#",
     },
     {
       name: "Amazon",
       logo: "/Amazon-Logo.png",
-      url: "https://companyC.com",
+      url: "#",
     },
     {
       name: "Twitter",
       logo: "/Twitter-Logo.png",
-      url: "https://companyD.com",
+      url: "#",
     },
     {
       name: "TikTok",
       logo: "/TikTok-Logo.png",
-      url: "https://companyE.com",
+      url: "#",
     },
     {
       name: "Youtube",
       logo: "/YouTube-Logo.png",
-      url: "https://companyF.com",
+      url: "#",
     },
     {
       name: "Messager",
       logo: "/Messenger-Logo.png",
-      url: "https://companyG.com",
+      url: "#",
     },
     {
       name: "WhatsApp",
       logo: "/WhatsApp-Logo.png",
-      url: "https://companyH.com",
+      url: "#",
     },
     {
       name: "Snapchat",
       logo: "/Snapchat-Logo.png",
-      url: "https://companyI.com",
+      url: "#",
     },
   ];
 


### PR DESCRIPTION
Replace actual company URLs with placeholders to facilitate the use of employer logos without linking to external sites.