### PR TITLE
Update database provider to PostgreSQL in Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,6 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url  	    = env("DATABASE_URL")
 }


### PR DESCRIPTION
Switch the database provider from SQLite to PostgreSQL in the Prisma schema.