### PR TITLE
Add Employer model to Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,3 +10,15 @@ datasource db {
   provider  = "postgresql"
   url  	    = env("DATABASE_URL")
 }
+
+model Employer {
+  id          String   @id
+  companyName String
+  industry    String?
+  description String?
+  websiteUrl  String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user        User     @relation(fields: [id], references: [id])
+}


### PR DESCRIPTION
Introduce the Employer model to the Prisma schema to facilitate the management of employer-related data.